### PR TITLE
Roles middleware

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class HomeController extends Controller
+{
+    public function home()
+    {
+        return view('home');
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Http;
 
+use App\Http\Middleware\CheckRole;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 
 class Kernel extends HttpKernel
@@ -56,5 +57,6 @@ class Kernel extends HttpKernel
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'role' => CheckRole::class,
     ];
 }

--- a/app/Http/Middleware/CheckRole.php
+++ b/app/Http/Middleware/CheckRole.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+class CheckRole
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next, $role)
+    {
+        if (!$request->user()->hasRole($role) && !$request->user()->isSuperAdmin()) {
+            return redirect()->route('home')->withErrors('No tiene permisos para acceder a esta sección');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -30,4 +30,33 @@ class User extends Authenticatable
     protected $hidden = [
         'password', 'remember_token',
     ];
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function role()
+    {
+        return $this->belongsTo(Role::class);
+    }
+
+    /**
+     * Check if user has a specified role
+     *
+     * @param $role
+     * @return bool
+     */
+    public function hasRole($role)
+    {
+        return $role == $this->role->id;
+    }
+
+    /**
+     * Check if the user is a SuperAdmin
+     *
+     * @return bool
+     */
+    public function isSuperAdmin()
+    {
+        return $this->role->id == Role::SUPER_ADMIN;
+    }
 }

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,0 +1,8 @@
+@extends('layouts.master')
+
+@section('sidebar')
+@overwrite
+
+@section('content')
+    Home
+@stop

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -42,9 +42,6 @@
                                 <a href="{{ route('users.index') }}">Operadores</a>
                             </li>
                             <li>
-                                <a href="{!! url('/hello_world') !!}">Roles</a>
-                            </li>
-                            <li>
                                 <a href="#">Notificaciones</a>
                             </li>
                         </ul>

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,12 +23,14 @@ Route::get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm
 Route::post('password/reset', 'Auth\ResetPasswordController@reset');
 
 
+// Home
+Route::get('/', 'HomeController@home')->name('home');
+
 // Panel Routes
 Route::middleware(['auth'])->group( function () {
 
-    Route::resource('users','UserController');
-
-    Route::get('/', 'UserController@index');
-    Route::get('/panel', 'UserController@index');
+    Route::middleware(['role:' . \App\Role::ADMIN_USERS])->group( function () {
+        Route::resource('users','UserController');
+    });
 
 });


### PR DESCRIPTION
Se agregó un middleware para chequear el rol del usuario al entrar a una ruta. Si no tiene el rol correspondiente, lo redirige a la home con un mensaje de error.
También se eliminó el menú Roles en la navbar, ya que no vamos a tener el ABM de Roles.